### PR TITLE
reverseアイテム途中まで

### DIFF
--- a/game/src/components/Board.jsx
+++ b/game/src/components/Board.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import Square from "./Square";
 import "./Board.css";
 
-const Board = ({ winnerLines, squares, onClick}) => {
+const Board = ({ itemLocation, winnerLines, squares, onClick}) => {
   /**
    * マス目を表示する
    * @param {int} index
@@ -17,9 +17,13 @@ const Board = ({ winnerLines, squares, onClick}) => {
       };
     }
 
+    let reverseValue = ""
+    if (index === itemLocation) reverseValue = "reverse"
+
     return (
       <Square
         winnerSquare={winnerSquare}
+        item={reverseValue}
         squareValue={squares[index]}
         onClick={() => onClick(index)}
       />

--- a/game/src/components/Board.jsx
+++ b/game/src/components/Board.jsx
@@ -17,6 +17,13 @@ const Board = ({ itemLocation, winnerLines, squares, onClick}) => {
       };
     }
 
+    const squareValue = squares.map((value) => {
+      if (value === null) return null;
+      else if (value) return "X";
+      else return "O";
+    });
+    console.log(squareValue);
+
     let reverseValue = ""
     if (index === itemLocation) reverseValue = "reverse"
 
@@ -24,7 +31,7 @@ const Board = ({ itemLocation, winnerLines, squares, onClick}) => {
       <Square
         winnerSquare={winnerSquare}
         item={reverseValue}
-        squareValue={squares[index]}
+        squareValue={squareValue[index]}
         onClick={() => onClick(index)}
       />
     );

--- a/game/src/components/Game.jsx
+++ b/game/src/components/Game.jsx
@@ -12,10 +12,18 @@ const Game = () => {
   const [disabledClick, setDisabledClick] = useState(false);
   const [playCount, setPlayCount] = useState(0);
   const randomLocation = Math.floor(Math.random() * 9);
-  console.log("randomLocation is " + randomLocation)
   const [reverseLocation, setReverseLocation] = useState(randomLocation);
-
   const MAX_PLAY_COUNT = 5;
+  
+  const jumpTo = (step) => {
+    if (step === 0){
+      addHidden();
+      setReverseLocation(randomLocation);
+      console.log("randomLocation is " + reverseLocation)
+    };
+    setPlayCount(step);
+    setXIsNext(step % 2 === 0);
+  };
 
   const moves = history.map((step, move) => {
     const desc = move ? `Go to move # ${move}` : `Restart`;
@@ -25,15 +33,6 @@ const Game = () => {
     if (move === 0){
       restart = "restart";
     }else visibility = "hidden";
-
-    const jumpTo = (step) => {
-      if (step === 0){
-        addHidden();
-        setReverseLocation(randomLocation());
-      };
-      setPlayCount(step);
-      setXIsNext(step % 2 === 0);
-    };
 
     return (
       <li key={move}

--- a/game/src/components/Game.jsx
+++ b/game/src/components/Game.jsx
@@ -47,6 +47,22 @@ const Game = () => {
       </li>
     );
   });
+  
+
+  /** 
+   * reverse
+  */
+ const reverse = () => {
+    let squareClasses = document.querySelectorAll(".square")
+
+    const reversed = (e) => {
+      // 配列を反転させる。
+    };
+
+    squareClasses.forEach((target) => {
+      target.addEventListener('click', reversed, false);
+    })
+  };
 
   /**
    * マス目クリック時
@@ -54,7 +70,7 @@ const Game = () => {
    */
   const handleClick = (index) => {
     setDisabledClick(true);
-
+    reverse();
     const historyCurrent = history.slice(0, playCount + 1);
     const current = historyCurrent[historyCurrent.length - 1];
     const squares = current.squares.slice();
@@ -62,7 +78,7 @@ const Game = () => {
     if (calculateWinner(squares) || squares[index]) {
       return;
     }
-    squares[index] = xIsNext ? "X" : "O";
+    squares[index] = xIsNext ? true : false;
 
     setPlayCount(historyCurrent.length);
     setHistory([...historyCurrent, { squares }]);
@@ -114,7 +130,7 @@ const Game = () => {
 
     const action_hand = possible_hands[Math.floor(Math.random() * possible_hands.length)];
     const cpuStatus = !xIsNext;
-    squares[action_hand] = cpuStatus ? "X" : "O";
+    squares[action_hand] = cpuStatus ? true : false;
 
     setHistory([...currentHistory, { squares }]);
     setXIsNext(xIsNext);
@@ -164,7 +180,8 @@ const Game = () => {
   let result = "";
   if (winner) {
     removeHidden();
-    result = "勝者: " + current.squares[winner[0]];
+    const winnerStatus = current.squares[winner[0]] ? "X" : "O"
+    result = "勝者: " + winnerStatus;
   } else if (playCount === MAX_PLAY_COUNT) {
     removeHidden();
     result = "引き分けです";

--- a/game/src/components/Game.jsx
+++ b/game/src/components/Game.jsx
@@ -48,17 +48,15 @@ const Game = () => {
     );
   });
   
+  const reversed = (e) => {
+   console.log(e.target.id);
+  };
 
   /** 
-   * reverse
+   * squareがクリックされたらreversed実行
   */
  const reverse = () => {
     let squareClasses = document.querySelectorAll(".square")
-
-    const reversed = (e) => {
-      // 配列を反転させる。
-    };
-
     squareClasses.forEach((target) => {
       target.addEventListener('click', reversed, false);
     })

--- a/game/src/components/Game.jsx
+++ b/game/src/components/Game.jsx
@@ -11,6 +11,9 @@ const Game = () => {
   const [xIsNext, setXIsNext] = useState(true);
   const [disabledClick, setDisabledClick] = useState(false);
   const [playCount, setPlayCount] = useState(0);
+  const randomLocation = Math.floor(Math.random() * 9);
+  console.log("randomLocation is " + randomLocation)
+  const [reverseLocation, setReverseLocation] = useState(randomLocation);
 
   const MAX_PLAY_COUNT = 5;
 
@@ -24,7 +27,10 @@ const Game = () => {
     }else visibility = "hidden";
 
     const jumpTo = (step) => {
-      if (step === 0){addHidden()};
+      if (step === 0){
+        addHidden();
+        setReverseLocation(randomLocation());
+      };
       setPlayCount(step);
       setXIsNext(step % 2 === 0);
     };
@@ -174,6 +180,7 @@ const Game = () => {
         <div className="display">{result}</div>
         <Board
           winnerLines={winner}
+          itemLocation={reverseLocation}
           squares={current.squares}
           onClick={index => handleClick(index)}
         />

--- a/game/src/components/Square.jsx
+++ b/game/src/components/Square.jsx
@@ -1,12 +1,13 @@
 import React from "react";
 import "./Square.css";
 
-const Square = ({winnerSquare, squareValue, onClick}) => {
+const Square = ({ item, winnerSquare, squareValue, onClick }) => {
 	console.log(winnerSquare);
 	let square = "square " + winnerSquare
 	return (
       <button
 				className={square}
+				id={item}
 				onClick={() => onClick()}
 				>
 				{squareValue}


### PR DESCRIPTION
次から細かくpushしていきます。
今回は以下の機能を追加しました。

- 初期レンダリングのタイミングでreverseをランダム配置
- Restart実行で再度ランダム配置
- square全てにeventListener追加（reverse関数）
- reverseさせるため、historyの中身をbooleanにしました。

現状、reverseSquareが押されるとコンソールで”reverse”と出ます。

打ったあとのマス目をクリックするとフリーズするバグ内容が更新されました。

> X を押すとフリーズ、O を押すと X に変化して続行になります。